### PR TITLE
Handle '', '*', '1.x.', 'URL#semver:...', etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,27 @@
 'use strict'
 
-// Consider it a range if we see any of the symbols ^~<>| or a digit followed by ".x"
-var regex = /[\^~<>|]|\d\.x/
+// Consider it a range if we detect:
+//  - An empty string
+//  - Any of the symbols ^*~<>|
+//  - A digit followed by .x
+//  - A hyphenated range like "a.b.c - d.e.f"
+const rangeRegEx = /^$|[\^*~<>|]|(\d+\.x)|(\d+(\.\d)*\s*-\s*\d+(\.\d)*)/
+const commitishSemverRegEx = /#semver:(.*)$/
 
-module.exports = function exactVersion (version) {
-  return !regex.test(version)
+function extractSemVer (s) {
+  let result = null
+  if (typeof s === 'string') {
+    const match = s.match(commitishSemverRegEx)
+    if (match) {
+      result = match[1]
+    }
+  }
+  return result
+}
+
+module.exports = function exactVersion (versionString) {
+  const nestedSemVer = extractSemVer(versionString)
+  const semVerString = nestedSemVer === null ? versionString : nestedSemVer
+
+  return !rangeRegEx.test(semVerString)
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-var regex = /\^|~|<|>|\|/
+// Consider it a range if we see any of the symbols ^~<>| or a digit followed by ".x"
+var regex = /[\^~<>|]|\d\.x/
 
 module.exports = function exactVersion (version) {
   return !regex.test(version)

--- a/index.js
+++ b/index.js
@@ -6,20 +6,21 @@
 //  - A digit followed by .x
 //  - A hyphenated range like "a.b.c - d.e.f"
 const rangeRegEx = /^$|[\^*~<>|]|(\d+\.x)|(\d+(\.\d)*\s*-\s*\d+(\.\d)*)/
-const commitishSemverRegEx = /#semver:(.*)$/
+const nestedSemVerRegEx = /#semver:(.*)$/
 
 function extractSemVer (s) {
   let result = null
-  if (typeof s === 'string') {
-    const match = s.match(commitishSemverRegEx)
-    if (match) {
-      result = match[1]
-    }
+  const match = s.match(nestedSemVerRegEx)
+  if (match) {
+    result = match[1]
   }
   return result
 }
 
 module.exports = function exactVersion (versionString) {
+  if (typeof versionString !== 'string') {
+    return false
+  }
   const nestedSemVer = extractSemVer(versionString)
   const semVerString = nestedSemVer === null ? versionString : nestedSemVer
 

--- a/index.js
+++ b/index.js
@@ -9,12 +9,8 @@ const rangeRegEx = /^$|[\^*~<>|]|(\d+\.x)|(\d+(\.\d)*\s*-\s*\d+(\.\d)*)/
 const nestedSemVerRegEx = /#semver:(.*)$/
 
 function extractSemVer (s) {
-  let result = null
   const match = s.match(nestedSemVerRegEx)
-  if (match) {
-    result = match[1]
-  }
-  return result
+  return match && match[1]
 }
 
 module.exports = function exactVersion (versionString) {

--- a/test.js
+++ b/test.js
@@ -1,15 +1,61 @@
 'use strict'
 
-var test = require('tape')
-var exact = require('./')
+const test = require('tape')
+const exact = require('./')
 
-test(function (t) {
+test('exact versions -> true', function (t) {
   t.ok(exact('4.0.0'))
   t.ok(exact('=4.0.0'))
+  t.end()
+})
+
+test('range versions -> false', function (t) {
   t.notOk(exact('~4.0.0'))
   t.notOk(exact('^4.0.0'))
+  t.notOk(exact('1.2.x'))
   t.notOk(exact('>= 4.0.0'))
   t.notOk(exact('<= 4.0.0'))
   t.notOk(exact('4.0.0 || 4.0.1'))
+  t.end()
+})
+
+const baseURLs = [
+  'git@github.com:bendrucker/exact-version.git#master',
+  'github.com:bendrucker/exact-version.git',
+  'bendrucker/exact-version.git',
+  'https://github.com:bendrucker/exact-version.git',
+  'git+ssh://git@github.com:substack/tape.git'
+]
+
+const rangeRefs = [
+  '#semver:^5.0',
+  '#semver:~1.2.0',
+  '#semver:2.x'
+]
+
+const exactRefs = [
+  '#master',
+  '#jj-abrams',
+  '#9bfce8f957a80c93d5c6365377d07a59034c6482',
+  '#semver:1.0.0'
+]
+
+test('exact commitish strings -> true', function (t) {
+  baseURLs.forEach((baseURL) => {
+    exactRefs.forEach((ref) => {
+      const s = `${baseURL}${ref}`
+      t.ok(exact(s), `${s} is exact`)
+    })
+  })
+  t.end()
+})
+
+test('range commit-ish strings -> false', function (t) {
+  baseURLs.forEach((baseURL) => {
+    rangeRefs.forEach((ref) => {
+      const s = `${baseURL}${ref}`
+      t.notOk(exact(s), `${s} refers to a range`)
+    })
+  })
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -3,33 +3,6 @@
 const test = require('tape')
 const exact = require('./')
 
-test('exact versions -> true', function (t) {
-  [
-    '4.0.0',
-    '1.8.3-beta.1',
-    '=4.0.0' // Note: this doesn't appear to be part of the official spec
-  ].forEach(input => t.ok(exact(input), input))
-  t.end()
-})
-
-test('range versions -> false', function (t) {
-  [
-    '',
-    '*',
-    '~4.0.0',
-    '^4.0.0',
-    '1.x',
-    '3.15.x',
-    '>= 4.0.0',
-    '<= 4.0.0',
-    '>=2.0.0 <=2.2.3',
-    '>=1.0.0 <=1.0.0', // Although mathematically ">=1.0.0 <=1.0.0" is a range of 1, we still treat it this as a range
-    '2.0.0 - 2.2.3',
-    '4.0.0 || 4.0.1'
-  ].forEach(input => t.notOk(exact(input), input))
-  t.end()
-})
-
 const baseURLs = [
   'git@github.com:bendrucker/exact-version.git#master',
   'github.com:bendrucker/exact-version.git',
@@ -53,30 +26,40 @@ const exactRefs = [
   '#semver:1.0.0'
 ]
 
-const exactURLs = baseURLs.reduce((urls, baseURL) => {
-  return urls.concat(exactRefs.map(ref => `${baseURL}${ref}`))
-}, [])
+const generateUrls = (baseURLs, refs) => {
+  return baseURLs.reduce((urls, baseURL) => {
+    return urls.concat(refs.map(ref => `${baseURL}${ref}`))
+  }, [])
+}
 
-const rangeURLs = baseURLs.reduce((urls, baseURL) => {
-  return urls.concat(rangeRefs.map(ref => `${baseURL}${ref}`))
-}, [])
+const exactURLs = generateUrls(baseURLs, exactRefs)
+const rangeURLs = generateUrls(baseURLs, rangeRefs)
 
-test('exact commitish strings -> true', function (t) {
-  exactURLs.forEach(url => t.ok(exact(url), url))
+test('exact versions -> true', function (t) {
+  [
+    '4.0.0',
+    '1.8.3-beta.1',
+    '=4.0.0', // Note: this doesn't appear to be part of the official spec
+    'http://asdf.com/asdf.tar.gz',
+    '../some/file.js'
+  ].concat(exactURLs).forEach(input => t.ok(exact(input), input))
   t.end()
 })
 
-test('range commitish strings -> true', function (t) {
-  rangeURLs.forEach(url => t.notOk(exact(url), url))
-  t.end()
-})
-
-test('Miscellaneous exact -> true', function (t) {
-  const url = 'http://asdf.com/asdf.tar.gz'
-  t.ok(exact(url), `URL ('${url}') should be considered exact`)
-
-  const localFile = '../some/file.js'
-  t.ok(exact(localFile), `Local file ('${localFile}') should be considered exact`)
-
+test('range versions -> false', function (t) {
+  [
+    '',
+    '*',
+    '~4.0.0',
+    '^4.0.0',
+    '1.x',
+    '3.15.x',
+    '>= 4.0.0',
+    '<= 4.0.0',
+    '>=2.0.0 <=2.2.3',
+    '>=1.0.0 <=1.0.0', // Although mathematically ">=1.0.0 <=1.0.0" is a range of 1, we still treat it this as a range
+    '2.0.0 - 2.2.3',
+    '4.0.0 || 4.0.1'
+  ].concat(rangeURLs).forEach(input => t.notOk(exact(input), input))
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -4,27 +4,29 @@ const test = require('tape')
 const exact = require('./')
 
 test('exact versions -> true', function (t) {
-  console.log('--------------\r\n\r\n')
-  t.ok(exact('4.0.0'), 'Typical 3-tiered version number')
-  console.log('\r\n\r\n')
-  t.ok(exact('1.8.3-beta.1'), 'Tagged version')
-  t.ok(exact('=4.0.0'), "= (this doesn't appear to be part of the official spec)")
+  [
+    '4.0.0',
+    '1.8.3-beta.1',
+    '=4.0.0' // Note: this doesn't appear to be part of the official spec
+  ].forEach(input => t.ok(exact(input), input))
   t.end()
 })
 
 test('range versions -> false', function (t) {
-  t.notOk(exact(''), 'Blank/empty is the same as *')
-  t.notOk(exact('*'), '* means anything')
-  t.notOk(exact('~4.0.0'), '~ specifies as range')
-  t.notOk(exact('^4.0.0', '^ specifies a range'))
-  t.notOk(exact('1.x'), '<digit>.x specifies a range')
-  t.notOk(exact('3.15.x'), '<digit>.<digit>.x specifies a range')
-  t.notOk(exact('>= 4.0.0'), '>= specifies a range')
-  t.notOk(exact('<= 4.0.0'), '<= specifies a range')
-  t.notOk(exact('>=2.0.0 <=2.2.3'), '>= and <= specify ranges')
-  t.notOk(exact('>=1.0.0 <=1.0.0'), 'Although mathematically ">=1.0.0 <=1.0.0" is a range of 1, we still treat it this as a range')
-  t.notOk(exact('2.0.0 - 2.2.3'), 'Hyphen is just like >= and <=')
-  t.notOk(exact('4.0.0 || 4.0.1'), 'Logical OR should be considered a range')
+  [
+    '',
+    '*',
+    '~4.0.0',
+    '^4.0.0',
+    '1.x',
+    '3.15.x',
+    '>= 4.0.0',
+    '<= 4.0.0',
+    '>=2.0.0 <=2.2.3',
+    '>=1.0.0 <=1.0.0', // Although mathematically ">=1.0.0 <=1.0.0" is a range of 1, we still treat it this as a range
+    '2.0.0 - 2.2.3',
+    '4.0.0 || 4.0.1'
+  ].forEach(input => t.notOk(exact(input), input))
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -48,18 +48,26 @@ const rangeRefs = [
 
 const exactRefs = [
   '#master',
-  '#jj-abrams',
+  '#something-with-hyphens',
   '#9bfce8f957a80c93d5c6365377d07a59034c6482',
   '#semver:1.0.0'
 ]
 
+const exactURLs = baseURLs.reduce((urls, baseURL) => {
+  return urls.concat(exactRefs.map(ref => `${baseURL}${ref}`))
+}, [])
+
+const rangeURLs = baseURLs.reduce((urls, baseURL) => {
+  return urls.concat(rangeRefs.map(ref => `${baseURL}${ref}`))
+}, [])
+
 test('exact commitish strings -> true', function (t) {
-  baseURLs.forEach((baseURL) => {
-    exactRefs.forEach((ref) => {
-      const s = `${baseURL}${ref}`
-      t.ok(exact(s), `${s} is exact`)
-    })
-  })
+  exactURLs.forEach(url => t.ok(exact(url), url))
+  t.end()
+})
+
+test('range commitish strings -> true', function (t) {
+  rangeURLs.forEach(url => t.notOk(exact(url), url))
   t.end()
 })
 
@@ -70,15 +78,5 @@ test('Miscellaneous exact -> true', function (t) {
   const localFile = '../some/file.js'
   t.ok(exact(localFile), `Local file ('${localFile}') should be considered exact`)
 
-  t.end()
-})
-
-test('range commit-ish strings -> false', function (t) {
-  baseURLs.forEach((baseURL) => {
-    rangeRefs.forEach((ref) => {
-      const s = `${baseURL}${ref}`
-      t.notOk(exact(s), `${s} refers to a range`)
-    })
-  })
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -4,18 +4,27 @@ const test = require('tape')
 const exact = require('./')
 
 test('exact versions -> true', function (t) {
-  t.ok(exact('4.0.0'))
-  t.ok(exact('=4.0.0'))
+  console.log('--------------\r\n\r\n')
+  t.ok(exact('4.0.0'), 'Typical 3-tiered version number')
+  console.log('\r\n\r\n')
+  t.ok(exact('1.8.3-beta.1'), 'Tagged version')
+  t.ok(exact('=4.0.0'), "= (this doesn't appear to be part of the official spec)")
   t.end()
 })
 
 test('range versions -> false', function (t) {
-  t.notOk(exact('~4.0.0'))
-  t.notOk(exact('^4.0.0'))
-  t.notOk(exact('1.2.x'))
-  t.notOk(exact('>= 4.0.0'))
-  t.notOk(exact('<= 4.0.0'))
-  t.notOk(exact('4.0.0 || 4.0.1'))
+  t.notOk(exact(''), 'Blank/empty is the same as *')
+  t.notOk(exact('*'), '* means anything')
+  t.notOk(exact('~4.0.0'), '~ specifies as range')
+  t.notOk(exact('^4.0.0', '^ specifies a range'))
+  t.notOk(exact('1.x'), '<digit>.x specifies a range')
+  t.notOk(exact('3.15.x'), '<digit>.<digit>.x specifies a range')
+  t.notOk(exact('>= 4.0.0'), '>= specifies a range')
+  t.notOk(exact('<= 4.0.0'), '<= specifies a range')
+  t.notOk(exact('>=2.0.0 <=2.2.3'), '>= and <= specify ranges')
+  t.notOk(exact('>=1.0.0 <=1.0.0'), 'Although mathematically ">=1.0.0 <=1.0.0" is a range of 1, we still treat it this as a range')
+  t.notOk(exact('2.0.0 - 2.2.3'), 'Hyphen is just like >= and <=')
+  t.notOk(exact('4.0.0 || 4.0.1'), 'Logical OR should be considered a range')
   t.end()
 })
 
@@ -30,6 +39,8 @@ const baseURLs = [
 const rangeRefs = [
   '#semver:^5.0',
   '#semver:~1.2.0',
+  '#semver:*',
+  '#semver:',
   '#semver:2.x'
 ]
 
@@ -47,6 +58,16 @@ test('exact commitish strings -> true', function (t) {
       t.ok(exact(s), `${s} is exact`)
     })
   })
+  t.end()
+})
+
+test('Miscellaneous exact -> true', function (t) {
+  const url = 'http://asdf.com/asdf.tar.gz'
+  t.ok(exact(url), `URL ('${url}') should be considered exact`)
+
+  const localFile = '../some/file.js'
+  t.ok(exact(localFile), `Local file ('${localFile}') should be considered exact`)
+
   t.end()
 })
 


### PR DESCRIPTION
This PR makes the following changes:

* Correctly detect ranges specified with ".x" notation, e.g. `1.0.x` 
* Correctly detect ranges specified with `*`, `''`, or `a.b.c - d.e.f` notation
* Improve test coverage, e.g. commitish URLs with exact (e.g. `#hash`) and range (e.g. `#semver:~1.0.0`)

(see https://docs.npmjs.com/files/package.json#dependencies)