### PR TITLE
Support inclusive ranges

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var regex = /\^|~|<|>|\||( \- )/
+var regex = /\^|~|<|>|\||( - )/
 
 module.exports = function exactVersion (version) {
   return !regex.test(version)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var regex = /\^|~|<|>|\|/
+var regex = /\^|~|<|>|\||( \- )/
 
 module.exports = function exactVersion (version) {
   return !regex.test(version)

--- a/test.js
+++ b/test.js
@@ -11,5 +11,6 @@ test(function (t) {
   t.notOk(exact('>= 4.0.0'))
   t.notOk(exact('<= 4.0.0'))
   t.notOk(exact('4.0.0 || 4.0.1'))
+  t.notOk(exact('4 - 4.0.1'))
   t.end()
 })


### PR DESCRIPTION
Issue:
exact-version returns true for an inclusive range when it should return false.

Solution:
update the parsing logic to enable it to understand inclusive ranges.